### PR TITLE
pytest version updated and pytest-parallel updated to pytest-xdist

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-selenium>=3.14
-pytest==7.1.3
+selenium>=4.38.0
+pytest==8.4.2
 pytest-selenium
-pytest-parallel
+pytest-xdist


### PR DESCRIPTION
<img width="1512" height="982" alt="Screenshot 2025-11-02 at 6 35 10 PM" src="https://github.com/user-attachments/assets/f225be5c-4281-4e5e-b580-ad6053abce9e" />
pytest-xdist replaced pytest-parallel because it’s the actively maintained, stable, and officially supported plugin for parallel test execution with modern Python and pytest versions.